### PR TITLE
feat: add sidebar layout and pagination to catatan page

### DIFF
--- a/src/components/catatan/CatatanList.tsx
+++ b/src/components/catatan/CatatanList.tsx
@@ -1,41 +1,26 @@
-import { useEffect, useState } from "react";
-
 import CatatanItem from "./CatatanItem";
-import supabase from "../../lib/supabase";
 
 type Catatan = {
   id: string;
-  judul_catatan: string;
-  isi_catatan: string | null;
+  title: string;
+  content: string;
+  category_id: string | null;
+  folder_id: string | null;
   created_at: string;
+  updated_at: string;
 };
 
-const CatatanList = () => {
-  const [catatan, setCatatan] = useState<Catatan[]>([]);
-  const [loading, setLoading] = useState(true);
+interface CatatanListProps {
+  catatan: Catatan[];
+  loading?: boolean;
+}
 
-  useEffect(() => {
-    const fetchCatatan = async () => {
-      setLoading(true);
-      const { data, error } = await supabase
-        .from("catatan")
-        .select("id, judul_catatan, isi_catatan, created_at")
-        .order("created_at", { ascending: false });
-
-      if (error) {
-        console.error("Gagal fetch catatan:", error.message);
-      } else {
-        setCatatan(data || []);
-      }
-      setLoading(false);
-    };
-
-    fetchCatatan();
-  }, []);
-
+const CatatanList = ({ catatan, loading = false }: CatatanListProps) => {
   if (loading) return <p className="text-center">Loading catatan...</p>;
-  if (catatan.length === 0)
+
+  if (catatan.length === 0) {
     return <p className="text-center">Belum ada catatan.</p>;
+  }
 
   return (
     <div className="space-y-4">
@@ -43,8 +28,8 @@ const CatatanList = () => {
         <CatatanItem
           key={item.id}
           id={item.id}
-          judul={item.judul_catatan}
-          isi={item.isi_catatan}
+          judul={item.title}
+          isi={item.content}
           createdAt={item.created_at}
         />
       ))}

--- a/src/components/catatan/CatatanListPaginated.tsx
+++ b/src/components/catatan/CatatanListPaginated.tsx
@@ -1,0 +1,157 @@
+import { useState, useEffect } from "react";
+
+import CatatanList from "./CatatanList";
+import { usePagination } from "../../hooks/usePagination";
+import supabase from "../../lib/supabase";
+
+interface Catatan {
+  id: string;
+  title: string;
+  content: string;
+  kategori_id: string | null;
+  folder_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface CatatanListPaginatedProps {
+  selectedCategory: string | null;
+  selectedFolder: string | null;
+}
+
+export default function CatatanListPaginated({
+  selectedCategory,
+  selectedFolder,
+}: CatatanListPaginatedProps) {
+  const [allCatatan, setAllCatatan] = useState<Catatan[]>([]);
+  const [filteredCatatan, setFilteredCatatan] = useState<Catatan[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const { currentItems, hasMore, loadMore, reset, currentPage, totalItems } =
+    usePagination({
+      data: filteredCatatan,
+      itemsPerPage: 10,
+    });
+
+  // Fetch all catatan from Supabase
+  useEffect(() => {
+    const fetchCatatan = async () => {
+      try {
+        setLoading(true);
+
+        // Actual Supabase call
+        const { data, error } = await supabase
+          .from("catatan")
+          .select("*")
+          .order("created_at", { ascending: false });
+
+        if (error) {
+          console.error("Error fetching catatan:", error.message);
+          // Fallback to mock data if error
+          const mockData: Catatan[] = Array.from({ length: 25 }, (_, i) => ({
+            id: `catatan-${i + 1}`,
+            title: `Catatan ${i + 1}`,
+            content: `Ini adalah konten catatan ke-${i + 1}`,
+            kategori_id:
+              i % 3 === 0 ? "cat-1" : i % 3 === 1 ? "cat-2" : "cat-3",
+            folder_id: i % 2 === 0 ? "folder-1" : "folder-2",
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          }));
+          setAllCatatan(mockData);
+        } else {
+          // Transform data to match interface if needed
+          const transformedData: Catatan[] = data.map((item) => ({
+            id: item.id,
+            title: item.judul_catatan || item.title,
+            content: item.isi_catatan || item.content,
+            kategori_id: item.kategori_id,
+            folder_id: item.folder_id,
+            created_at: item.created_at,
+            updated_at: item.updated_at || item.created_at,
+          }));
+          setAllCatatan(transformedData);
+        }
+      } catch (error) {
+        console.error("Error fetching catatan:", error);
+        // Fallback to empty array
+        setAllCatatan([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCatatan();
+  }, []);
+
+  // Filter catatan based on selected category and folder
+  useEffect(() => {
+    let filtered = allCatatan;
+
+    if (selectedCategory) {
+      filtered = filtered.filter(
+        (catatan) => catatan.kategori_id === selectedCategory,
+      );
+    }
+
+    if (selectedFolder) {
+      filtered = filtered.filter(
+        (catatan) => catatan.folder_id === selectedFolder,
+      );
+    }
+
+    setFilteredCatatan(filtered);
+    reset(); // Reset pagination when filter changes
+  }, [allCatatan, selectedCategory, selectedFolder, reset]);
+
+  return (
+    <div className="space-y-4">
+      {/* Results Info */}
+      <div className="text-sm text-base-content/70">
+        Menampilkan {currentItems.length} dari {totalItems} catatan
+        {(selectedCategory || selectedFolder) && (
+          <span className="ml-2">(filtered)</span>
+        )}
+      </div>
+
+      {/* Catatan List */}
+      <CatatanList catatan={currentItems} loading={loading} />
+
+      {/* Load More Button */}
+      {hasMore && !loading && (
+        <div className="flex justify-center pt-4">
+          <button onClick={loadMore} className="btn btn-outline btn-primary">
+            Muat Lebih Banyak
+          </button>
+        </div>
+      )}
+
+      {/* No more items message */}
+      {!hasMore && totalItems > 10 && !loading && (
+        <div className="text-center text-sm text-base-content/50 pt-4">
+          Semua catatan telah ditampilkan
+        </div>
+      )}
+
+      {/* Empty state */}
+      {totalItems === 0 && !loading && (
+        <div className="text-center py-12">
+          <div className="text-4xl mb-4">📝</div>
+          <h3 className="text-lg font-medium mb-2">Belum ada catatan</h3>
+          <p className="text-base-content/60">
+            {selectedCategory || selectedFolder
+              ? "Tidak ada catatan untuk filter yang dipilih"
+              : "Mulai dengan membuat catatan baru"}
+          </p>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {loading && (
+        <div className="flex justify-center items-center h-64">
+          <div className="loading loading-spinner loading-lg"></div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/catatan/CatatanMainLayout.tsx
+++ b/src/components/catatan/CatatanMainLayout.tsx
@@ -1,0 +1,227 @@
+import { useState, useEffect } from "react";
+
+import CatatanSidebar from "./CatatanSidebar";
+import CatatanListPaginated from "./CatatanListPaginated";
+import FormCatatanAdd from "../forms/FormCatatanAdd";
+import supabase from "../../lib/supabase";
+
+interface Category {
+  id: string;
+  name: string;
+  count: number;
+}
+
+interface Folder {
+  id: string;
+  name: string;
+  count: number;
+}
+
+export default function CatatanMainLayout() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [folders, setFolders] = useState<Folder[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedFolder, setSelectedFolder] = useState<string | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  // Fetch categories from Supabase
+  const fetchCategories = async () => {
+    try {
+      const { data: categoriesData, error: categoriesError } = await supabase
+        .from("kategori_catatan")
+        .select("id, nama")
+        .order("nama");
+
+      if (categoriesError) {
+        console.error("Error fetching categories:", categoriesError);
+        return;
+      }
+
+      // Get count for each category (assuming you have a catatan table with kategori_id)
+      const categoriesWithCount = await Promise.all(
+        categoriesData.map(async (category) => {
+          const { count } = await supabase
+            .from("catatan") // Sesuaikan dengan nama tabel catatan Anda
+            .select("*", { count: "exact", head: true })
+            .eq("kategori_id", category.id);
+
+          return {
+            id: category.id,
+            name: category.nama,
+            count: count || 0,
+          };
+        }),
+      );
+
+      setCategories(categoriesWithCount);
+    } catch (error) {
+      console.error("Error fetching categories:", error);
+    }
+  };
+
+  // Fetch folders from Supabase
+  const fetchFolders = async () => {
+    try {
+      const { data: foldersData, error: foldersError } = await supabase
+        .from("folder_catatan")
+        .select("id, nama")
+        .order("nama");
+
+      if (foldersError) {
+        console.error("Error fetching folders:", foldersError);
+        return;
+      }
+
+      // Get count for each folder (assuming you have a catatan table with folder_id)
+      const foldersWithCount = await Promise.all(
+        foldersData.map(async (folder) => {
+          const { count } = await supabase
+            .from("catatan") // Sesuaikan dengan nama tabel catatan Anda
+            .select("*", { count: "exact", head: true })
+            .eq("folder_id", folder.id);
+
+          return {
+            id: folder.id,
+            name: folder.nama,
+            count: count || 0,
+          };
+        }),
+      );
+
+      setFolders(foldersWithCount);
+    } catch (error) {
+      console.error("Error fetching folders:", error);
+    }
+  };
+
+  // Load data on component mount
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([fetchCategories(), fetchFolders()]);
+      setLoading(false);
+    };
+
+    loadData();
+  }, []);
+
+  const handleAddNew = () => {
+    setShowAddForm(true);
+  };
+
+  const handleFormSuccess = async () => {
+    console.log("Catatan berhasil ditambahkan!");
+    setShowAddForm(false);
+    // Refresh data after adding new catatan
+    await Promise.all([fetchCategories(), fetchFolders()]);
+  };
+
+  const handleFormCancel = () => {
+    console.log("Cancelled");
+    setShowAddForm(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen bg-base-100">
+        <div className="w-64 bg-base-200 p-4 min-h-screen">
+          <div className="animate-pulse space-y-4">
+            <div className="h-10 bg-base-300 rounded"></div>
+            <div className="space-y-2">
+              <div className="h-4 bg-base-300 rounded w-20"></div>
+              <div className="h-8 bg-base-300 rounded"></div>
+              <div className="h-8 bg-base-300 rounded"></div>
+              <div className="h-8 bg-base-300 rounded"></div>
+            </div>
+          </div>
+        </div>
+        <div className="flex-1 p-6">
+          <div className="max-w-4xl mx-auto">
+            <div className="animate-pulse space-y-4">
+              <div className="h-8 bg-base-300 rounded w-40"></div>
+              <div className="h-4 bg-base-300 rounded w-60"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen bg-base-100">
+      {/* Sidebar */}
+      <CatatanSidebar
+        categories={categories}
+        folders={folders}
+        onAddNew={handleAddNew}
+        onCategorySelect={setSelectedCategory}
+        onFolderSelect={setSelectedFolder}
+        selectedCategory={selectedCategory}
+        selectedFolder={selectedFolder}
+      />
+
+      {/* Main Content */}
+      <div className="flex-1 p-6">
+        <div className="max-w-4xl mx-auto">
+          {/* Header */}
+          <div className="mb-6">
+            <h1 className="text-3xl font-bold mb-2">Catatan</h1>
+            <p className="text-base-content/60">
+              Kelola semua catatan Anda dengan mudah
+            </p>
+          </div>
+
+          {/* Filter Badge */}
+          {(selectedCategory || selectedFolder) && (
+            <div className="mb-4 flex gap-2">
+              {selectedCategory && (
+                <div className="badge badge-primary gap-2">
+                  Kategori:{" "}
+                  {categories.find((c) => c.id === selectedCategory)?.name}
+                  <button
+                    onClick={() => setSelectedCategory(null)}
+                    className="btn btn-ghost btn-xs"
+                  >
+                    ×
+                  </button>
+                </div>
+              )}
+              {selectedFolder && (
+                <div className="badge badge-secondary gap-2">
+                  Folder: {folders.find((f) => f.id === selectedFolder)?.name}
+                  <button
+                    onClick={() => setSelectedFolder(null)}
+                    className="btn btn-ghost btn-xs"
+                  >
+                    ×
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Catatan List with Pagination */}
+          <CatatanListPaginated
+            selectedCategory={selectedCategory}
+            selectedFolder={selectedFolder}
+          />
+        </div>
+      </div>
+
+      {/* Add Form Modal */}
+      {showAddForm && (
+        <div className="modal modal-open">
+          <div className="modal-box max-w-2xl">
+            <h3 className="font-bold text-lg mb-4">Tambah Catatan Baru</h3>
+            <FormCatatanAdd
+              onSuccess={handleFormSuccess}
+              onCancel={handleFormCancel}
+            />
+          </div>
+          <div className="modal-backdrop" onClick={handleFormCancel}></div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/catatan/CatatanSidebar.tsx
+++ b/src/components/catatan/CatatanSidebar.tsx
@@ -1,0 +1,125 @@
+import { Plus, Tag, Folder } from "lucide-react";
+
+interface Category {
+  id: string;
+  name: string;
+  count: number;
+}
+
+interface FolderItem {
+  id: string;
+  name: string;
+  count: number;
+}
+
+interface CatatanSidebarProps {
+  categories: Category[];
+  folders: FolderItem[];
+  onAddNew: () => void;
+  onCategorySelect: (categoryId: string | null) => void;
+  onFolderSelect: (folderId: string | null) => void;
+  selectedCategory: string | null;
+  selectedFolder: string | null;
+}
+
+export default function CatatanSidebar({
+  categories,
+  folders,
+  onAddNew,
+  onCategorySelect,
+  onFolderSelect,
+  selectedCategory,
+  selectedFolder,
+}: CatatanSidebarProps) {
+  return (
+    <div className="w-64 bg-base-200 p-4 min-h-screen">
+      {/* Add New Button */}
+      <button onClick={onAddNew} className="btn btn-primary w-full mb-6 gap-2">
+        <Plus size={18} />
+        Tambah Catatan Baru
+      </button>
+
+      {/* Categories Section */}
+      <div className="mb-6">
+        <div className="flex items-center gap-2 mb-3">
+          <Tag size={16} />
+          <h3 className="font-semibold text-sm">Kategori</h3>
+        </div>
+        <ul className="space-y-1">
+          <li>
+            <button
+              onClick={() => onCategorySelect(null)}
+              className={`w-full text-left px-3 py-2 rounded text-sm hover:bg-base-300 ${
+                selectedCategory === null ? "bg-base-300 font-medium" : ""
+              }`}
+            >
+              Semua Kategori
+            </button>
+          </li>
+          {categories.length > 0 ? (
+            categories.map((category) => (
+              <li key={category.id}>
+                <button
+                  onClick={() => onCategorySelect(category.id)}
+                  className={`w-full text-left px-3 py-2 rounded text-sm hover:bg-base-300 flex justify-between ${
+                    selectedCategory === category.id
+                      ? "bg-base-300 font-medium"
+                      : ""
+                  }`}
+                >
+                  <span>{category.name}</span>
+                  <span className="text-xs opacity-60">{category.count}</span>
+                </button>
+              </li>
+            ))
+          ) : (
+            <li className="px-3 py-2 text-sm text-base-content/60">
+              Belum ada kategori
+            </li>
+          )}
+        </ul>
+      </div>
+
+      {/* Folders Section */}
+      <div>
+        <div className="flex items-center gap-2 mb-3">
+          <Folder size={16} />
+          <h3 className="font-semibold text-sm">Folder</h3>
+        </div>
+        <ul className="space-y-1">
+          <li>
+            <button
+              onClick={() => onFolderSelect(null)}
+              className={`w-full text-left px-3 py-2 rounded text-sm hover:bg-base-300 ${
+                selectedFolder === null ? "bg-base-300 font-medium" : ""
+              }`}
+            >
+              Semua Folder
+            </button>
+          </li>
+          {folders.length > 0 ? (
+            folders.map((folder) => (
+              <li key={folder.id}>
+                <button
+                  onClick={() => onFolderSelect(folder.id)}
+                  className={`w-full text-left px-3 py-2 rounded text-sm hover:bg-base-300 flex justify-between ${
+                    selectedFolder === folder.id
+                      ? "bg-base-300 font-medium"
+                      : ""
+                  }`}
+                >
+                  <span>{folder.name}</span>
+                  <span className="text-xs opacity-60">{folder.count}</span>
+                </button>
+              </li>
+            ))
+          ) : (
+            <li className="px-3 py-2 text-sm text-base-content/60">
+              Belum ada folder
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,56 @@
+import { useState, useEffect, useCallback } from "react"; // Import useCallback
+
+interface UsePaginationProps<T> {
+  data: T[];
+  itemsPerPage?: number;
+}
+
+interface UsePaginationReturn<T> {
+  currentItems: T[];
+  hasMore: boolean;
+  loadMore: () => void;
+  reset: () => void;
+  currentPage: number;
+  totalItems: number;
+}
+
+export function usePagination<T>({
+  data,
+  itemsPerPage = 10,
+}: UsePaginationProps<T>): UsePaginationReturn<T> {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalItems = data.length;
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const startIndex = 0;
+  const endIndex = currentPage * itemsPerPage;
+
+  const currentItems = data.slice(startIndex, endIndex);
+  const hasMore = currentPage < totalPages;
+
+  // Wrap loadMore with useCallback
+  const loadMore = useCallback(() => {
+    if (hasMore) {
+      setCurrentPage((prev) => prev + 1);
+    }
+  }, [hasMore]); // hasMore sebagai dependensi
+
+  // Wrap reset with useCallback
+  const reset = useCallback(() => {
+    setCurrentPage(1);
+  }, []); // Dependency array kosong agar fungsi ini stabil
+
+  // Reset pagination when data changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [data.length]);
+
+  return {
+    currentItems,
+    hasMore,
+    loadMore,
+    reset,
+    currentPage,
+    totalItems,
+  };
+}

--- a/src/pages/CatatanPage.tsx
+++ b/src/pages/CatatanPage.tsx
@@ -1,21 +1,5 @@
-import CatatanList from "../components/catatan/CatatanList";
-import FormCatatanAdd from "../components/forms/FormCatatanAdd";
+import CatatanMainLayout from "../components/catatan/CatatanMainLayout";
 
 export default function CatatanPage() {
-  const handleSuccess = () => {
-    console.log("Catatan berhasil ditambahkan!");
-    // Redirect or refresh data
-  };
-
-  const handleCancel = () => {
-    console.log("Cancelled");
-    // Close modal or navigate back
-  };
-  return (
-    <>
-      <h1>Halaman Catatan</h1>
-      <FormCatatanAdd onSuccess={handleSuccess} onCancel={handleCancel} />
-      <CatatanList />
-    </>
-  );
+  return <CatatanMainLayout />;
 }


### PR DESCRIPTION
Refactor catatan page to use modular components with improved UX including sidebar navigation, pagination, and filtering capabilities.
- **Created `usePagination` hook**: Reusable pagination logic with 10 items per page
- **Added `CatatanSidebar`**: Navigation component with filtering capabilities
- **Added `CatatanListPaginated`**: Paginated list with filtering integration
- **Added `CatatanMainLayout`**: Main layout combining all components
- **Refactored `CatatanPage`**: Simplified to use new modular structure