### PR TITLE
fix: Correct CI/CD push branch to main

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -3,7 +3,7 @@ name: CI for nyatetApp
 on:
   push:
     branches:
-      - workflow-test
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This PR corrects the `on: push: branches:` configuration in the CI/CD workflow to properly trigger on pushes to the `main` branch.

Previously, the `push` trigger was still configured for `workflow-test`, preventing automated CI runs upon direct pushes or merges into `main`. This fix ensures that CI jobs (build and test) are executed whenever changes land on the main branch, as intended.