### PR TITLE
Improve mobile layout by reducing excessive padding

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 1rem;
 }

--- a/src/components/catatan/CatatanDetail.tsx
+++ b/src/components/catatan/CatatanDetail.tsx
@@ -157,7 +157,7 @@ const CatatanDetail = ({ id }: Props) => {
     return <p className="text-center text-error">Catatan not found.</p>;
 
   return (
-    <div className="p-6 space-y-6 max-w-4xl mx-auto w-full">
+    <div className="p-3 space-y-6 max-w-4xl mx-auto w-full">
       {toast.show && (
         <ToastAlert
           type={toast.type}

--- a/src/components/catatan/CatatanMainLayout.tsx
+++ b/src/components/catatan/CatatanMainLayout.tsx
@@ -267,7 +267,7 @@ const CatatanMainLayout = () => {
           </div>
         </div>
 
-        <main className="flex-1 p-4 overflow-y-auto">
+        <main className="flex-1 p-3 overflow-y-auto">
           <h1 className="text-3xl font-bold mb-6">Daftar Catatan</h1>
           <CatatanListPaginated
             selectedCategory={selectedCategory}
@@ -286,7 +286,7 @@ const CatatanMainLayout = () => {
           }}
         >
           <div
-            className="fixed left-0 top-0 h-full bg-base-200 w-64 p-4 z-50 overflow-y-auto"
+            className="fixed left-0 top-0 h-full bg-base-200 p-4 z-50 overflow-y-auto"
             onClick={(e) => {
               e.stopPropagation();
             }}


### PR DESCRIPTION
This PR improves the mobile layout by reducing excessive padding that caused content to appear too narrow on small screens. The main adjustments include:
- Reducing root padding in `App.css` from 2rem to 1rem
- Decreasing some inner content paddings for better spacing and readability