### PR TITLE
Refactor Markdown Renderer: Arabic Text Support and Component Extraction

### DIFF
--- a/src/components/catatan/CatatanDetail.tsx
+++ b/src/components/catatan/CatatanDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import ReactMarkdown from "react-markdown";
 import {
@@ -16,6 +16,10 @@ import {
 } from "lucide-react";
 import supabase from "../../lib/supabase";
 import ToastAlert from "../ToastAlert";
+
+import { getPlainText } from "../../utils/markdown";
+import CustomParagraph from "../markdown/CustomParagraph";
+import CustomHeading from "../markdown/CustomHeading";
 
 interface Props {
   id: string;
@@ -37,25 +41,6 @@ interface ToastType {
   message: string;
   show: boolean;
 }
-
-const getPlainText = (node: React.ReactNode): string => {
-  if (typeof node === "string" || typeof node === "number") {
-    return String(node);
-  }
-  if (Array.isArray(node)) {
-    return node.map(getPlainText).join("");
-  }
-  // Periksa elemen React (misalnya <em>, <strong>)
-  if (React.isValidElement(node)) {
-    // Type assertion: Memberi tahu TypeScript bahwa props elemen ini mungkin memiliki properti children.
-    const elementProps = node.props as { children?: React.ReactNode };
-
-    if (elementProps.children !== undefined) {
-      return getPlainText(elementProps.children);
-    }
-  }
-  return ""; // Abaikan tipe lain (boolean, null, undefined) atau elemen tanpa children
-};
 
 const CatatanDetail = ({ id }: Props) => {
   const [catatan, setCatatan] = useState<Catatan | null>(null);
@@ -259,94 +244,17 @@ const CatatanDetail = ({ id }: Props) => {
       <article className="prose prose-lg dark:prose-invert max-w-none">
         <ReactMarkdown
           components={{
-            p: ({ children }) => {
-              const textContent = getPlainText(children);
+            p: CustomParagraph,
 
-              const hasArabic =
-                /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(
-                  textContent,
-                );
-              const hasLatin = /[A-Za-z]/.test(textContent);
-
-              if (hasArabic && !hasLatin) {
-                return (
-                  <p
-                    className="font-arabic mb-4 leading-relaxed text-gray-800 dark:text-gray-200 text-right"
-                    dir="rtl"
-                  >
-                    {children}
-                  </p>
-                );
-              } else if (hasArabic && hasLatin) {
-                return (
-                  <p
-                    className="mb-4 leading-relaxed text-gray-800 dark:text-gray-200 text-left"
-                    dir="ltr"
-                  >
-                    <span
-                      className="font-arabic inline-block w-full text-right"
-                      dir="rtl"
-                    >
-                      {children}
-                    </span>
-                  </p>
-                );
-              } else {
-                return (
-                  <p className="mb-4 leading-relaxed text-gray-800 dark:text-gray-200">
-                    {children}
-                  </p>
-                );
-              }
-            },
-            h1: ({ children }) => {
-              const textContent = getPlainText(children);
-              const hasArabic =
-                /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(
-                  textContent,
-                );
-
-              return (
-                <h1
-                  className={`text-2xl font-bold mb-4 mt-8 first:mt-0 text-gray-900 dark:text-gray-100 ${hasArabic ? "font-arabic text-right" : ""}`}
-                  dir={hasArabic ? "rtl" : "ltr"}
-                >
-                  {children}
-                </h1>
-              );
-            },
-            h2: ({ children }) => {
-              const textContent = getPlainText(children);
-              const hasArabic =
-                /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(
-                  textContent,
-                );
-
-              return (
-                <h2
-                  className={`text-xl font-semibold mb-3 mt-6 first:mt-0 text-gray-900 dark:text-gray-100 ${hasArabic ? "font-arabic text-right" : ""}`}
-                  dir={hasArabic ? "rtl" : "ltr"}
-                >
-                  {children}
-                </h2>
-              );
-            },
-            h3: ({ children }) => {
-              const textContent = getPlainText(children);
-              const hasArabic =
-                /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(
-                  textContent,
-                );
-
-              return (
-                <h3
-                  className={`text-lg font-medium mb-2 mt-5 first:mt-0 text-gray-900 dark:text-gray-100 ${hasArabic ? "font-arabic text-right" : ""}`}
-                  dir={hasArabic ? "rtl" : "ltr"}
-                >
-                  {children}
-                </h3>
-              );
-            },
+            h1: ({ children }) => (
+              <CustomHeading level={1}>{children}</CustomHeading>
+            ),
+            h2: ({ children }) => (
+              <CustomHeading level={2}>{children}</CustomHeading>
+            ),
+            h3: ({ children }) => (
+              <CustomHeading level={3}>{children}</CustomHeading>
+            ),
             ul: ({ children }) => (
               <ul className="list-disc list-inside mb-4 space-y-2 text-gray-800 dark:text-gray-200 ml-4">
                 {children}

--- a/src/components/markdown/CustomHeading.tsx
+++ b/src/components/markdown/CustomHeading.tsx
@@ -1,0 +1,35 @@
+import React, { type JSX } from "react";
+import { getPlainText } from "../../utils/markdown";
+
+interface CustomHeadingProps {
+  children: React.ReactNode;
+  level: 1 | 2 | 3; // Menentukan level heading
+}
+
+const CustomHeading = ({ children, level }: CustomHeadingProps) => {
+  const textContent = getPlainText(children);
+  const hasArabic =
+    /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(
+      textContent,
+    );
+
+  const Tag = `h${String(level)}` as keyof JSX.IntrinsicElements;
+
+  let className =
+    "font-bold mb-4 mt-8 first:mt-0 text-gray-900 dark:text-gray-100";
+  if (level === 1) className = `text-2xl ${className}`;
+  if (level === 2) className = `text-xl font-semibold mb-3 mt-6 ${className}`;
+  if (level === 3) className = `text-lg font-medium mb-2 mt-5 ${className}`;
+
+  return (
+    <Tag
+      className={`${className} ${hasArabic ? "font-arabic text-right" : ""}`}
+      dir={hasArabic ? "rtl" : "ltr"}
+    >
+      {children}
+    </Tag>
+  );
+};
+
+export default CustomHeading;
+

--- a/src/components/markdown/CustomParagraph.tsx
+++ b/src/components/markdown/CustomParagraph.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+import { getPlainText } from "../../utils/markdown";
+
+const CustomParagraph = ({
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>) => {
+  const textContent = getPlainText(children);
+  const hasArabic =
+    /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(
+      textContent,
+    );
+  const hasLatin = /[A-Za-z]/.test(textContent);
+
+  const processChild = (
+    child: React.ReactNode,
+    index: number,
+  ): React.ReactNode => {
+    if (typeof child === "string") {
+      const parts = child.split(
+        /([\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF\s]{4,})/,
+      );
+
+      return parts.map((part, i) => {
+        const isArabic =
+          /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(
+            part,
+          );
+        const uniqueKey = `${part}-${i.toString()}-${index.toString()}`;
+        return isArabic ? (
+          <span key={uniqueKey} dir="rtl" className="font-arabic">
+            {part}
+          </span>
+        ) : (
+          <React.Fragment key={uniqueKey}>{part}</React.Fragment>
+        );
+      });
+    } else if (Array.isArray(child)) {
+      return (child as React.ReactNode[]).map((item, i) =>
+        processChild(item, i),
+      );
+    } else if (React.isValidElement(child)) {
+      interface ChildElementProps {
+        children?: React.ReactNode;
+        [key: string]: unknown;
+      }
+      const typedChildProps = child.props as ChildElementProps;
+      const newProps = {
+        ...typedChildProps,
+        key: child.key ?? `element-${index.toString()}`,
+      };
+      const childrenToProcess = typedChildProps.children;
+
+      return React.createElement(
+        child.type,
+        newProps,
+        childrenToProcess !== undefined && childrenToProcess !== null
+          ? processChild(childrenToProcess, 0)
+          : undefined,
+      );
+    }
+    return child;
+  };
+
+  if (hasArabic && !hasLatin && textContent.trim().length > 10) {
+    return (
+      <p
+        className="font-arabic mb-4 leading-relaxed text-gray-800 dark:text-gray-200 text-right"
+        dir="rtl"
+        {...props}
+      >
+        {children}
+      </p>
+    );
+  }
+
+  return (
+    <p
+      className="mb-4 leading-relaxed text-gray-800 dark:text-gray-200"
+      {...props}
+    >
+      {processChild(children, 0)}{" "}
+    </p>
+  );
+};
+
+export default CustomParagraph;
+

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,17 @@
+import React from "react";
+
+export const getPlainText = (node: React.ReactNode): string => {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(getPlainText).join("");
+  }
+  if (React.isValidElement(node)) {
+    const elementProps = node.props as { children?: React.ReactNode };
+    if (elementProps.children !== undefined) {
+      return getPlainText(elementProps.children);
+    }
+  }
+  return "";
+};


### PR DESCRIPTION
This PR enhances the markdown rendering system with better handling of Arabic text and structural refactoring for improved maintainability.

- Arabic text rendering now distinguishes between full Arabic paragraphs (rendered RTL) and inline Arabic within Latin text (kept inline, LTR).
- Extracted custom paragraph and heading renderers into separate components: `components/markdown/CustomParagraph.tsx `and `components/markdown/CustomHeading.tsx`.
- Moved getPlainText() function into a dedicated utility file: `src/utils/markdown.ts`